### PR TITLE
Logout before removing the cookie

### DIFF
--- a/rac.py
+++ b/rac.py
@@ -41,9 +41,8 @@ class RAC(object):
         self.sid = self._extract_sid(resp)
 
     def _logout(self):
-        self.sid = None
         self._make_request('/logout')
-
+        self.sid = None
     def run_command(self, cmd):
         if self.sid is None:
             self._login()


### PR DESCRIPTION
The run_command was logging out the user every time, although the sessions would not clear up in the iDrac because the SID was not sent as part of the logout. This led to not being able to login for a while till the sessions timed out.